### PR TITLE
[IMP] Added code to restrict the Sales Orders transaction in the Reconcile screen if Journal is not added in the Reconcile model

### DIFF
--- a/account_reconcile_sale_order/models/account_reconciliation_widget.py
+++ b/account_reconcile_sale_order/models/account_reconciliation_widget.py
@@ -53,6 +53,16 @@ class AccountReconciliationWidget(models.AbstractModel):
         )
         sale_orders = []
         if mode == "rp":
+            stmt_line = self.env['account.bank.statement.line'].browse(st_line_id)
+            if stmt_line.journal_id:
+                # Search reconcile model in which journal of the
+                # bank statement line match with Available Journal
+                journal_matching_model = self.env["account.reconcile.model"].search([
+                    ("rule_type", "=", "sale_order_matching"),
+                    ("match_journal_ids", "=", stmt_line.journal_id.id)
+                ])
+                if not journal_matching_model:
+                    return result
             sale_orders = self._get_sale_orders_for_bank_statement_line(
                 st_line_id,
                 partner_id=partner_id,

--- a/account_reconcile_sale_order/views/account_reconcile_model.xml
+++ b/account_reconcile_sale_order/views/account_reconcile_model.xml
@@ -3,11 +3,6 @@
         <field name="model">account.reconcile.model</field>
         <field name="inherit_id" ref="account.view_account_reconcile_model_form" />
         <field name="arch" type="xml">
-            <group id="conditions_tab_group" position="attributes">
-                <attribute
-                    name="attrs"
-                >{'invisible': [('rule_type', '=', 'sale_order_matching')]}</attribute>
-            </group>
             <group id="conditions_tab_group" position="after">
                 <group
                     name="account_reconcile_sale_order"
@@ -19,7 +14,29 @@
                         attrs="{'invisible': [('sale_order_matching_token_match', '=', False)]}"
                     />
                     </group>
-                    </group>
+                </group>
+                <field name="match_nature" position="attributes">
+                    <attribute 
+                        name="attrs"
+                    >{'invisible': [('rule_type', 'in', ['writeoff_button', 'sale_order_matching'])]}</attribute>
+                </field>
+                <group
+                    style="width:100% !important"
+                    attrs="{'invisible': [('rule_type', '=', 'writeoff_button')]}"
+                    position="attributes"
+                >
+                    <attribute
+                        name="attrs"
+                    >{'invisible': [('rule_type', 'in', ['writeoff_button', 'sale_order_matching'])]}</attribute>
+                </group>
+                <group id="right column" position="attributes">
+                    <attribute
+                        name="attrs"
+                    >{'invisible': [('rule_type', 'in', ['writeoff_button', 'sale_order_matching'])]}</attribute>
+                </group>
+                <field name="match_journal_ids" position="attributes">
+                    <attribute name="attrs">{'required': [('rule_type', '=', 'sale_order_matching')]}</attribute>
+                </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
1) Make "Journals Availability" field visible in the reconcile model
2) If no Journal is selected in "Journals Availability", then Sales transactions will not show in the reconciliation screen
3) If any Journal is selected, then Sales transactions will show in that specific journal.

<img width="625" height="569" alt="image" src="https://github.com/user-attachments/assets/dde6c3e9-0039-47c4-ab28-7539a8c66de5" />
